### PR TITLE
Fix spacing in preview for bullet list

### DIFF
--- a/handbook.md
+++ b/handbook.md
@@ -21,6 +21,7 @@ Bulleted lists should not have commas at the end nor be phrased as one long sent
 - red
 - green
 - blue
+
 and not:
 - red, 
 - green, 


### PR DESCRIPTION
It wasn't obvious which set of bullet points to list because the preview for MD was making them run together.